### PR TITLE
typo: calender -> calendar

### DIFF
--- a/officedocs-dev-ucma-api/xml/Microsoft.Rtc.Collaboration.Presence/LocalPresentityNotificationEventArgs.xml
+++ b/officedocs-dev-ucma-api/xml/Microsoft.Rtc.Collaboration.Presence/LocalPresentityNotificationEventArgs.xml
@@ -55,7 +55,7 @@
         <remarks>
           <para>
             This is the overall presence state that is the aggregated from all of the local owner's endpoint, manual, phone
-            and calender states.
+            and calendar states.
             </para>
           <para />
         </remarks>


### PR DESCRIPTION
This is likely auto-generated, but I don't know the source repo